### PR TITLE
chore: update dependencies for design tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.1.1",
-        "@edx/frontend-component-footer": "^14.0.0",
+        "@edx/frontend-component-footer": "github:PKulkoRaccoonGang/frontend-component-footer#Peter_Kulko/support-design-tokens",
         "@openedx/frontend-build": "^14.0.3",
         "core-js": "3.37.1",
         "glob": "7.2.3",
@@ -2187,9 +2187,8 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-14.0.4.tgz",
-      "integrity": "sha512-VsbooOSWoGQVAn881vH8mLe+gNRP2hcNsOhQ8YJ89Enu0LPaJla5OhUIKRtbAGKrwicEBxFqxqpirhOGCmxgtQ==",
+      "version": "1.0.0-semantically-released",
+      "resolved": "git+ssh://git@github.com/PKulkoRaccoonGang/frontend-component-footer.git#e97fb6617f8ec0b4d86a244afa79e9820b51879c",
       "dev": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -2204,7 +2203,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "@openedx/paragon": ">= 21.11.3 < 23.0.0",
+        "@openedx/paragon": ">= 21.11.3 < 23.0.0 || 23.0.0-alpha.1",
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react": "^17.0.0"
   },
   "devDependencies": {
-    "@edx/frontend-component-footer": "^14.0.0",
+    "@edx/frontend-component-footer": "github:PKulkoRaccoonGang/frontend-component-footer#Peter_Kulko/support-design-tokens",
     "@edx/browserslist-config": "^1.1.1",
     "@openedx/frontend-build": "^14.0.3",
     "core-js": "3.37.1",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the dependency for `@edx/frontend-component-footer`. The change switches from a versioned dependency to a GitHub repository reference.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R42): Changed the `@edx/frontend-component-footer` dependency to point to a specific branch in a GitHub repository (`github:PKulkoRaccoonGang/frontend-component-footer#Peter_Kulko/support-design-tokens`).