### PR TITLE
fix: publish DEPR notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # frontend-slot-footer
 
-🛑🛑🛑 
+🛑🛑🛑
+
 This Component is deprecated and is no longer how you should be mananing customizations 
 to your footer.  The default `frontend-component-footer` now provides slots that can be
 overridden for making modifications.
@@ -8,6 +9,7 @@ overridden for making modifications.
 See more details about that here: https://github.com/openedx/frontend-component-footer/tree/master/src/plugin-slots
 
 See the relevant DEPR ticket for more info here: https://github.com/openedx/frontend-component-footer/issues/459
+
 🛑🛑🛑 
 
 This package provides a wrapped version of the lms and studio footer using [Frontend Plugin Framework](https://github.com/openedx/frontend-plugin-framework).


### PR DESCRIPTION
https://github.com/openedx/frontend-slot-footer/pull/82 landed as a `docs` commit which doesn't trigger a semantic release. This uses `fix` so the new README will make it to `npm`.